### PR TITLE
Use std:c++17 because c++20 deletes ostream for wchar_t

### DIFF
--- a/blesonwin/setup.py
+++ b/blesonwin/setup.py
@@ -68,7 +68,7 @@ class Publish(SimpleCommand):
 
 blesonwin_module = Extension('blesonwin',                              
                              sources = ['blesonwin.cpp'],
-                             extra_compile_args = ["/std:c++latest"], 
+                             extra_compile_args = ["/std:c++17"],
                              )
 
 setup(name = 'blesonwin', 


### PR DESCRIPTION
This allows us to build on MSVC2019 which has a newer latest standard